### PR TITLE
Fix contact page by exporting default component

### DIFF
--- a/mega-site-feat-fx-and-previews/ST_MARYS_FRAMEWORK/app/contact/page.tsx
+++ b/mega-site-feat-fx-and-previews/ST_MARYS_FRAMEWORK/app/contact/page.tsx
@@ -1,0 +1,7 @@
+export default function ContactPage() {
+  return (
+    <div>
+      {/* TODO: Add contact content later */}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds a default exported ContactPage component to the contact page to ensure that Next.js recognizes it as a module and can compile successfully.