### PR TITLE
Fix resources page by exporting default component

### DIFF
--- a/mega-site-feat-fx-and-previews/ST_MARYS_FRAMEWORK/app/resources/page.tsx
+++ b/mega-site-feat-fx-and-previews/ST_MARYS_FRAMEWORK/app/resources/page.tsx
@@ -1,0 +1,7 @@
+export default function ResourcesPage() {
+  return (
+    <div>
+      {/* TODO: Add resources content later */}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR fixes the resources page by exporting a default component, allowing Next.js to recognize it as a valid module.